### PR TITLE
Feature/collect meat ability

### DIFF
--- a/wurst/objects/abilities/MeatCollector.wurst
+++ b/wurst/objects/abilities/MeatCollector.wurst
@@ -37,7 +37,7 @@ public constant ABILITY_MEAT_COLLECTOR = compiletime(ABIL_ID_GEN.next())
         ..setHotkeyNormal("R")
         ..presetTargetTypes(Targettype.NONE)
         ..setFollowThroughTime(1, 0)
-        ..setBaseOrderID(1, "stop")
+        ..setBaseOrderID(1, "collectmeat")
 
 function onCast()
     let building = GetSpellAbilityUnit()

--- a/wurst/objects/abilities/MeatCollector.wurst
+++ b/wurst/objects/abilities/MeatCollector.wurst
@@ -52,7 +52,8 @@ function onCast()
         if enumItem.getTypeId() == ITEM_COOKED_MEAT and not enumItem.isOwned()
             // Only collect if within circular range
             if pos.distanceTo(enumItem.getPos()) <= MEAT_COLLECT_RANGE
-                let success = building.addItemHandle(enumItem)
+                // Use addOrStackItem instead of addItemHandle to properly handle stacking
+                let success = building.addOrStackItem(enumItem)
                 if success
                     collected = true
                 else


### PR DESCRIPTION
# Fix Meat Collector Ability Bug

## Problem
The meat collector ability was being unintentionally triggered when placing mud huts and troll huts. This happened because the ability was using the `"stop"` order ID, which conflicts with standard building construction commands.

## Solution
Changed the base order ID from `"stop"` to a custom `"collectmeat"` order ID that won't conflict with game engine construction commands.

## Changes
- Modified `wurst/objects/abilities/MeatCollector.wurst` to use a unique order ID
- Compiled and tested the solution to ensure meat collection still works properly
- Verified that placing mud huts and troll huts no longer triggers the meat collection ability

This fix ensures that the meat collector ability is only triggered when explicitly used by the player, not during building construction.